### PR TITLE
[MOSIP-34253] Added standalone (data-share-standalone.properties) for data-share application to enable it to share data using static data share policy in Inji-config.

### DIFF
--- a/data-share-default.properties
+++ b/data-share-default.properties
@@ -1,0 +1,64 @@
+# Follow properites have their values assigned via 'overrides' environment variables of config server docker.
+# DO NOT define these in any of the property files.  They must be passed as env variables.  Refer to config-server
+# helm chart:
+# keycloak.external.host
+# keycloak.external.url
+# keycloak.internal.host
+# keycloak.internal.url
+# mosip.datsha.client.secret
+# s3.accesskey 
+# s3.region
+# s3.secretkey
+
+mosip.data.share.service.id=mosip.data.share
+mosip.data.share.service.version=1.0
+
+CRYPTOMANAGER_ENCRYPT=${mosip.kernel.keymanager.url}/v1/keymanager/encrypt
+KEYMANAGER_JWTSIGN=${mosip.kernel.keymanager.url}/v1/keymanager/jwtSign
+PARTNER_POLICY=${mosip.pms.policymanager.url}/v1/policymanager/policies/{policyId}/partner/{partnerId}
+KEYBASEDTOKENAPI=${mosip.kernel.authmanager.url}/v1/authmanager/authenticate/clientidsecretkey
+
+
+data.share.application.id=PARTNER
+mosip.data.share.datetime.pattern=yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+!-- if value is true then  please set servlet path to /   --!
+mosip.data.share.urlshortner=false
+data.share.token.request.appid=datsha
+data.share.token.request.clientId=mosip-datsha-client
+data.share.token.request.secretKey=${mosip.datsha.client.secret}
+data.share.token.request.password=
+data.share.token.request.username=
+data.share.token.request.version=1.0
+data.share.token.request.id=io.mosip.datashare
+data.share.token.request.issuerUrl=${keycloak.internal.url}/auth/realms/mosip
+spring.servlet.multipart.max-file-size=14MB
+mosip.data.share.protocol=http
+mosip.data.share.includeCertificateHash=false
+mosip.data.share.includeCertificate=false
+mosip.data.share.includePayload=false
+mosip.data.share.digest.algorithm=SHA256
+mosip.data.share.prependThumbprint=false
+mosip.role.durian.postcreatepolicyidsubscriberid=CREATE_SHARE
+auth.server.admin.allowed.audience=mosip-creser-client,mpartner-default-auth,mosip-regproc-client,mosip-reg-client,mosip-syncdata-client,mpartner-default-print,mosip-resident-client,opencrvs-partner,mosip-pms-client,mpartner-default-digitalcard,mosip-admin-client,mosip-abis-client,mpartner-default-mobile
+
+mosip.auth.filter_disable=false
+
+# Object store
+object.store.s3.accesskey=${s3.accesskey}
+object.store.s3.secretkey=${s3.secretkey}
+## For Minio: object.store.s3.url=http://minio.minio:9000
+## For AWS: object.store.s3.url=s3.${s3.region}.amazonaws.com
+object.store.s3.url=http://minio.minio:9000
+object.store.s3.region=${s3.region}
+object.store.s3.readlimit=10000000
+
+#specific to Compliance Toolkit, to ABIS DataShare testcases
+auth.handle.ctk.flow=true
+mosip.api.internal.toolkit.url=https://${mosip.api.internal.host}/v1/toolkit
+mosip.compliance.toolkit.saveDataShareToken.url=${mosip.api.internal.toolkit.url}/saveDataShareToken
+mosip.compliance.toolkit.invalidateDataShareToken.url=${mosip.api.internal.toolkit.url}/invalidateDataShareToken
+mosip.compliance.toolkit.invalidateDataShareToken.testCaseId=ABIS3031
+logging.level.org.springframework.web: DEBUG
+#cache schedular
+mosip.data.share.policy-cache.expiry-time-millisec=7200000
+

--- a/data-share-standalone.properties
+++ b/data-share-standalone.properties
@@ -1,0 +1,15 @@
+# Enables the data-share application in standalone mode.
+mosip.data.share.standalone.mode.enabled=true
+# Defines the policy json which will be taken into consideration if
+# "mosip.data.share.standalone.mode.enabled" is set as true.
+# If we are using "encryptionType" as "Partner based" then subscriberId must be a valid subscriberId
+# i.e. should exist in system.
+mosip.data.share.static-policy.policy-json={"typeOfShare":"","transactionsAllowed":"2","shareDomain":"datashare.datashare","encryptionType":"NONE","source":"","validForInMinutes":"30"}
+# Defines the policyId which will be taken into consideration if "
+# mosip.data.share.standalone.mode.enabled" is set as true.
+mosip.data.share.static-policy.policy-id=static-policyid
+# Defines the subscriberId which will be taken into consideration if
+# "mosip.data.share.standalone.mode.enabled" is set as true.
+mosip.data.share.static-policy.subscriber-id=static-subscriberid
+# Disables JWT signature computation while storing object in object store.
+mosip.data.share.signature.disabled=true


### PR DESCRIPTION
[MOSIP-34253] Added standalone (data-share-standalone.properties) for data-share application to enable it to share data using static data share policy in Inji-config.

[MOSIP-34253]: https://mosip.atlassian.net/browse/MOSIP-34253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ