### PR TITLE
Update mimoto-issuers-config.json

### DIFF
--- a/mimoto-issuers-config.json
+++ b/mimoto-issuers-config.json
@@ -229,7 +229,7 @@
       "enabled": "true"
     },
     {
-      "credential_issuer": "testing1",
+      "credential_issuer": "Mosip",
       "display": [
         {
           "name": "National Identity Department",
@@ -295,10 +295,10 @@
       "protocol": "OpenId4VCI",
       "client_id": "${mimoto.oidc.mosipid.partner.clientid}",
       "client_alias": "mpartner-default-test-mosipid",
-      ".well-known": "http://inji-config-server.config-server/config/mimoto/default/qa/mimoto-mosipid-identity-wellknown.json",
+      ".well-known": "https://${mosip.injicertify.mosipid.host}/v1/certify/issuance/.well-known/openid-credential-issuer",
       "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
       "authorization_audience": "https://${mosip.esignet.mosipid.host}/v1/esignet/oauth/v2/token",
-      "token_endpoint": "https://${mosip.api.public.host}/v1/mimoto/get-token/testing1",
+      "token_endpoint": "https://${mosip.api.public.host}/v1/mimoto/get-token/Mosip",
       "proxy_token_endpoint": "https://${mosip.esignet.mosipid.host}/v1/esignet/oauth/v2/token",
       "enabled": "true"
     },
@@ -341,7 +341,6 @@
         }
       ],
       "protocol": "OpenId4VCI",
-      "client_id": "${mimoto.oidc.mock.partner.clientid}",
       "client_alias": "mpartner-mock-testing",
       ".well-known": "https://${mosip.injicertify.mock.host}/v1/certify/issuance/.well-known/openid-credential-issuer",
       "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",


### PR DESCRIPTION
reverted the old change and removed the clientid mandatory config for the new test case  scenario