### PR TITLE
[INJICERT-320] fix the credential id & credential.type disparity (#126)

### DIFF
--- a/certify-mock-identity.properties
+++ b/certify-mock-identity.properties
@@ -27,7 +27,7 @@ mosip.certify.key-values={\
               'credentials_supported': {\
                       {\
                           'format': 'ldp_vc',\
-                          'id': 'MockVerifiableCredential_ldp', \
+                          'id': 'MockVerifiableCredential', \
                           'scope' : 'mock_identity_vc_ldp',\
                           'cryptographic_binding_methods_supported': {'did:jwk'},\
                           'cryptographic_suites_supported': {'RsaSignature2018'},\
@@ -61,7 +61,7 @@ mosip.certify.key-values={\
               'credential_endpoint': '${mosip.certify.domain.url}${server.servlet.path}/issuance/vd12/credential', \
               'display': {{'name': 'Mock Verifiable Credential', 'locale': 'en'}},\
               'credentials_supported' : { \
-                 'MockVerifiableCredential_ldp' : {\
+                 'MockVerifiableCredential' : {\
                     'format': 'ldp_vc',\
                     'scope' : 'mock_identity_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
@@ -96,7 +96,7 @@ mosip.certify.key-values={\
               'credential_endpoint': '${mosip.certify.domain.url}${server.servlet.path}/issuance/credential', \
               'display': {{'name': 'Mock Verifiable Credential', 'locale': 'en'}},\
               'credential_configurations_supported' : { \
-                 'MockVerifiableCredential_ldp' : {\
+                 'MockVerifiableCredential' : {\
                     'format': 'ldp_vc',\
                     'scope' : 'mock_identity_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\

--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -77,7 +77,7 @@ mosip.certify.key-values={\
               'credential_endpoint': '${mosip.certify.domain.url}${server.servlet.path}/issuance/vd12/credential', \
               'display': {{'name': 'MOSIP National ID', 'locale': 'en'}},\
               'credentials_supported' : { \
-                 'MOSIPVerifiableCredential_ldp' : {\
+                 'MosipVerifiableCredential' : {\
                     'format': 'ldp_vc',\
                     'scope' : 'mosip_identity_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
@@ -115,7 +115,7 @@ mosip.certify.key-values={\
               'credential_endpoint': '${mosip.certify.domain.url}${server.servlet.path}/issuance/credential', \
               'display': {{'name': 'MOSIP National ID', 'locale': 'en'}},\
               'credential_configurations_supported' : { \
-                 'MOSIPVerifiableCredential_ldp' : {\
+                 'MosipVerifiableCredential' : {\
                     'format': 'ldp_vc',\
                     'scope' : 'mosip_identity_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\


### PR DESCRIPTION
similar change sent last week: https://github.com/mosip/inji-config/pull/126/files

Purpose: automation test runs for Inji Wallet