### PR TITLE
Update mimoto-mock-identity-wellknown.json

### DIFF
--- a/mimoto-mock-identity-wellknown.json
+++ b/mimoto-mock-identity-wellknown.json
@@ -12,8 +12,7 @@
         "jwt": {
           "proof_signing_alg_values_supported": [
             "RS256",
-            "PS256",
-            "ES256"
+            "PS256"
           ]
         }
       },


### PR DESCRIPTION
removed the  "ES256"  because it will not support to download the mock Vc