### PR TITLE
[INJICERT-434] remove vd11 from Insurance example

### DIFF
--- a/certify-sunbird-insurance.properties
+++ b/certify-sunbird-insurance.properties
@@ -38,68 +38,6 @@ mosip.certify.database.name=inji_certify_insurance
 
 mosip.certify.svg-templates=insurance-svg-template.json
 mosip.certify.key-values={\
- 'vd11' : {\
-              'credential_issuer': '${mosip.certify.identifier}',   \
-              'authorization_server': '${mosip.certify.authorization.url}', \
-              'credential_endpoint': '${mosip.certify.domain.url}${server.servlet.path}/issuance/vd11/credential', \
-              'display': {{'name': 'Insurance', 'locale': 'en'}},\
-              'credentials_supported': {{\
-                      'format': 'ldp_vc',\
-                      'id': 'InsuranceCredential', \
-                      'scope' : 'sunbird_rc_insurance_vc_ldp',\
-                      'cryptographic_binding_methods_supported': {'did:jwk'},\
-                      'cryptographic_suites_supported': {'Ed25519Signature2020'},\
-                      'proof_types_supported': {'jwt'},\
-                      'credential_definition': {\
-                        'type': {'VerifiableCredential','InsuranceCredential'},\
-                        'credentialSubject': {\
-                          'fullName': {'display': {{'name': 'Name','locale': 'en'}}}, \
-                          'mobile': {'display': {{'name': 'Phone Number','locale': 'en'}}},\
-                          'dob': {'display': {{'name': 'Date of Birth','locale': 'en'}}},\
-                          'gender': {'display': {{'name': 'Gender','locale': 'en'}}},\
-                          'benefits': {'display': {{'name': 'Benefits','locale': 'en'}}},\
-                          'email': {'display': {{'name': 'Email Id','locale': 'en'}}},\
-                          'policyIssuedOn': {'display': {{'name': 'Policy Issued On','locale': 'en'}}},\
-                          'policyExpiresOn': {'display': {{'name': 'Policy Expires On','locale': 'en'}}},\
-                          'policyName': {'display': {{'name': 'Policy Name','locale': 'en'}}},\
-                          'policyNumber': {'display': {{'name': 'Policy Number','locale': 'en'}}}\
-                         }},\
-                        'display': {{'name': 'Health Insurance', \
-                                    'locale': 'en', \
-                                    'logo': {'url': 'https://raw.githubusercontent.com/tw-mosip/file-server/master/StayProtectedInsurance.png', 'alt_text': 'a square logo of a Veridonia'},\
-                                    'background_color': '#FDFAF9',\
-                                    'text_color': '#7C4616'}},\
-                        'order' : {'fullName','policyName','policyExpiresOn','policyIssuedOn','policyNumber','mobile','dob','gender','benefits','email'}\
-                  },\
-                  {\
-                      'format': 'ldp_vc',\
-                      'id': 'LifeInsuranceCredential', \
-                      'scope' : 'life_insurance_vc_ldp',\
-                      'cryptographic_binding_methods_supported': {'did:jwk'},\
-                      'cryptographic_suites_supported': {'Ed25519Signature2020'},\
-                      'proof_types_supported': {'jwt'},\
-                      'credential_definition': {\
-                          'type': {'VerifiableCredential', 'LifeInsuranceCredential'},\
-                          'credentialSubject': {\
-                              'fullName': {'display': {{'name': 'Name','locale': 'en'}}}, \
-                              'mobile': {'display': {{'name': 'Phone Number','locale': 'en'}}},\
-                              'dob': {'display': {{'name': 'Date of Birth','locale': 'en'}}},\
-                              'gender': {'display': {{'name': 'Gender','locale': 'en'}}},\
-                              'benefits': {'display': {{'name': 'Benefits','locale': 'en'}}},\
-                              'email': {'display': {{'name': 'Email Id','locale': 'en'}}},\
-                              'policyIssuedOn': {'display': {{'name': 'Policy Issued On','locale': 'en'}}},\
-                              'policyExpiresOn': {'display': {{'name': 'Policy Expires On','locale': 'en'}}},\
-                              'policyName': {'display': {{'name': 'Policy Name','locale': 'en'}}},\
-                              'policyNumber': {'display': {{'name': 'Policy Number','locale': 'en'}}}\
-                       }},\
-                      'display': {{'name': 'Life Insurance', \
-                                    'locale': 'en', \
-                                    'logo': {'url': 'https://raw.githubusercontent.com/tw-mosip/file-server/master/StayProtectedInsurance.png','alt_text': 'a square logo of a Veridonia'},\
-                                    'background_color': '#FDFAF9',\
-                                    'text_color': '#7C4616'}},\
-                       'order' : {'fullName','policyName','policyExpiresOn','policyIssuedOn','policyNumber','mobile','dob','gender','benefits','email'}\
-                  }}\
-          },\
    'vd12' : {\
               'credential_issuer': '${mosip.certify.identifier}',   \
               'authorization_servers': {'${mosip.certify.authorization.url}'}, \


### PR DESCRIPTION
Reason for removal: The well-known config was exceeding 10k lines, which was not being parsed by Spring.