### PR TITLE
[INJICERT-434] TEMP set the log level to debug IDA

### DIFF
--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -7,6 +7,7 @@
 mosip.certify.integration.scan-base-package=io.mosip.certify.mosipid.integration
 mosip.certify.integration.audit-plugin=IdaAuditPluginImpl
 mosip.certify.integration.vci-plugin=IdaVCIssuancePluginImpl
+logging.level.org.springframework.web.client.RestTemplate=DEBUG
 
 ## ------------------------------------------- Plugin specific usecase properties ------------------------------------------------------------
 


### PR DESCRIPTION
Reason: Not able to download the MOSIP UIN, checking why IDA failed & gave error code.