### PR TITLE
avoid loading mock VCIssuancePlugin for DataProviderPlugin impl

### DIFF
--- a/certify-mockdp-identity.properties
+++ b/certify-mockdp-identity.properties
@@ -15,7 +15,6 @@ mosip.certify.issuer.uri=https://vharsh.github.io/DID/mock-ed25519-ctrl-dev1.jso
 ## ------------------------------------------- Plugin enable properties ------------------------------------------------------------
 mosip.certify.integration.scan-base-package=io.mosip.certify.mock.integration
 mosip.certify.integration.audit-plugin=LoggerAuditService
-mosip.certify.integration.vci-plugin=MockVCIssuancePlugin
 mosip.certify.integration.data-provider-plugin=MockIdaDataProviderPlugin
 
 ## ------------------------------------------- Plugin specific usecase properties ------------------------------------------------------------


### PR DESCRIPTION
Reason: `DataProviderPlugin` implementation Certify shouldn't load a `VCIssuancePlugin` also.