### PR TITLE
Revert "[INJIVER-833] : Update certify-mockdp-identity.properties background image removal for national id"

### DIFF
--- a/certify-mockdp-identity.properties
+++ b/certify-mockdp-identity.properties
@@ -137,6 +137,7 @@ mosip.certify.key-values={\
                                   'locale': 'en', \
                                   'logo': {'url': 'https://${mosip.api.public.host}/inji/veridonia-logo.png','alt_text': 'a square logo of a MOSIP'},\
                                   'background_color': '#f8efea',\
+                                  'background_image': { 'uri': 'https://${mosip.api.public.host}/inji/mosip-logo.png' }, \
                                   'text_color': '#000000'}},\
                     'order' : {'UIN','fullName','gender','dateOfBirth','address','region','postalCode','phoneNumber','emailId'}\
                  }}\
@@ -170,6 +171,7 @@ mosip.certify.key-values={\
                                   'locale': 'en', \
                                   'logo': {'url': 'https://${mosip.api.public.host}/inji/veridonia-logo.png','alt_text': 'a square logo of a MOSIP'},\
                                   'background_color': '#f8efea',\
+                                  'background_image': { 'uri': 'https://${mosip.api.public.host}/inji/mosip-logo.png' }, \
                                   'text_color': '#000000'}},\
                     'order' : {'UIN','fullName','gender','dateOfBirth','address','region','postalCode','phoneNumber','emailId'}\
                  }}\


### PR DESCRIPTION
Reverts mosip/inji-config#579