### PR TITLE
Update certify-postgres-landregistry.properties

### DIFF
--- a/certify-postgres-landregistry.properties
+++ b/certify-postgres-landregistry.properties
@@ -8,9 +8,9 @@ mosip.certify.issuer=CertifyIssuer
 mosip.certify.vcformat.vc.expiry=true
 # optional field to specify VC signature algo for CertifyIssuer, defaults to Ed25519Signature2020
 # other option: [RsaSignature2018]
-mosip.certify.issuer.vc-sign-algo=Ed25519Signature2018
-mosip.certify.issuer.pub.key=did:web:likhitharl.github.io:vc:qainji#key-0
-mosip.certify.issuer.uri=did:web:likhitharl.github.io:vc:qainji
+mosip.certify.issuer.vc-sign-algo=Ed25519Signature2020
+mosip.certify.issuer.pub.key=did:web:vharsh.github.io:DID:qainjicp1#key-0
+mosip.certify.issuer.uri=did:web:vharsh.github.io:DID:qainjicp1
 mosip.certify.issuer.svg.template.id=
 mosip.certify.integration.data-provider-plugin=PostgresDataProviderPlugin
 # Mimoto -- INJIMOB-2446
@@ -103,7 +103,7 @@ mosip.certify.key-values={\
                     'format': 'ldp_vc',\
                     'scope' : 'land_registry_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
-                    'credential_signing_alg_values_supported': {'Ed25519Signature2018'},\
+                    'credential_signing_alg_values_supported': {'Ed25519Signature2020'},\
                     'proof_types_supported': {'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256'}}},\
                     'credential_definition': {\
                       'type': {'VerifiableCredential','RegistrationReceiptCredential'},\


### PR DESCRIPTION
Reverted changes to default config
mosip.certify.issuer.vc-sign-algo=Ed25519Signature2020 mosip.certify.issuer.pub.key=did:web:vharsh.github.io:DID:qainjicp1#key-0 mosip.certify.issuer.uri=did:web:vharsh.github.io:DID:qainjicp1