### PR TITLE
Revert "[INJICERT-657] Commented hsm keystore config with appropriate comment"

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -77,9 +77,7 @@ mosip.kernel.keymanager.hsm.keystore-type=PKCS11
 mosip.kernel.keymanager.hsm.config-path=/config/softhsm-application.conf
 # Passkey of keystore for PKCS11, PKCS12
 # For Offline & JCE proer can be left blank. JCE password use other JCE specific properties.
-# The below hsm keystore-pass variable in commented as it is expected to be received from an environment variable -> MOSIP_KERNEL_KEYMANAGER_HSM_KEYSTORE_PASS
-# This variable to be uncommented if it is to be passed on from the config server.
-#mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.security.pin}
+mosip.kernel.keymanager.hsm.keystore-pass=${softhsm.certify.security.pin}
 
 
 mosip.kernel.keymanager.certificate.default.common-name=www.example.com


### PR DESCRIPTION
Reverts mosip/inji-config#641