### PR TITLE
[INJIWEB-1203] add spring cache expiry property in mimoto-default properties file

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -59,6 +59,8 @@ mosip.data.share.get.url.pattern=${mosip.data.share.url}/v1/datashare/get/static
 
 #OpenId4VP related Configuration END
 
+#Caffeine cache related configurations
+cache.expiry.time.in.min = 60
 
 logging.level.org.springframework.web.client.RestTemplate=INFO
 


### PR DESCRIPTION
- We use this property in mimoto to clear the Authorization Server wellknown response we store in spring caffeine cache for every 60 minutes