### PR TITLE
Update certify-mosipid-identity.properties

### DIFF
--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -114,7 +114,7 @@ mosip.certify.key-values={\
    },\
   'latest' : {\
               'credential_issuer': '${mosip.certify.identifier}',   \
-              'authorization_servers': {'${mosip.certify.authorization.url}'}, \
+              'authorization_servers': {'https://esignet-mosipid.qa-platform1.mosip.net'}, \
               'credential_endpoint': '${mosip.certify.domain.url}${server.servlet.path}/issuance/credential', \
               'display': {{'name': 'MOSIP National ID', 'locale': 'en'}},\
               'credential_configurations_supported' : { \


### PR DESCRIPTION
changed  'authorization_servers': {'https://esignet-mosipid.qa-platform1.mosip.net'}, \