### PR TITLE
Update mimoto-issuers-config.json

### DIFF
--- a/mimoto-issuers-config.json
+++ b/mimoto-issuers-config.json
@@ -161,7 +161,6 @@
     {
       "issuer_id": "Mosip",
       "credential_issuer": "Mosip",
-      "credential_issuer_host": "https://${mosip.injicertify.mosipid.released.host}",
       "display": [
         {
           "name": "National Identity Department (Released)",


### PR DESCRIPTION
removed the complete "credential_issuer_host": "https://${mosip.injicertify.mosipid.released.host}",