### PR TITLE
Update mimoto-issuers-config.json

### DIFF
--- a/mimoto-issuers-config.json
+++ b/mimoto-issuers-config.json
@@ -160,8 +160,7 @@
     },
     {
       "issuer_id": "Mosip",
-      "credential_issuer": "Mosip",
-      "credential_issuer_host": "https://${mosip.injicertify.mosipid.released.host}",
+      "credential_issuer": "Mosip", 
       "display": [
         {
           "name": "National Identity Department (Released)",


### PR DESCRIPTION
removed "credential_issuer_host": "https://${mosip.injicertify.mosipid.released.host}", for mosip id