### PR TITLE
Update mimoto-default.properties

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -5,7 +5,7 @@ mosip.api.internal.url=https://${mosip.api.internal.host}
 mosip.api.public.url=https://${mosip.api.public.host}
 public.url=${mosip.api.internal.url}/residentmobileapp
 mosip.resident.base.url=${mosip.resident.url}/resident/v1
-idp.binding.base.url=https://${mosipid.identity.esignet.host}/v1/esignet/binding
+idp.binding.base.url=https://${mosipid.identity.esignet.collab.host}/v1/esignet/binding
 
 # Configurations related to openid4vci
 mosip.openid.issuers=mimoto-issuers-config.json


### PR DESCRIPTION
changed the idp.binding.base.url=https://${mosipid.identity.esignet.collab.host}/v1/esignet/binding