### PR TITLE
[INJIMOB-2810] modify client_id in trusted verifiers

### DIFF
--- a/mimoto-trusted-verifiers.json
+++ b/mimoto-trusted-verifiers.json
@@ -1,7 +1,7 @@
 {
   "verifiers": [
     {
-      "client_id": "https://${mosip.injiverify.host}",
+      "client_id": "mosip-inji-verify",
       "redirect_uris": [
         "https://${mosip.injiverify.host}/redirect"
       ],


### PR DESCRIPTION
As per OVP draft 23, client_id_scheme will be available as a prefix in client_id property and pre-registered clients MUST NOT contain a : character in their Client Identifier. The existing client_id had https://... which has semicolon available, to follow the pattern, the value has been modified