### PR TITLE
[INJICERT] remove Ed25519 proofjwt for mosipid

### DIFF
--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -131,7 +131,7 @@ mosip.certify.key-values={\
                     'scope' : 'mosip_identity_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
                     'credential_signing_alg_values_supported': {'RsaSignature2018'},\
-                    'proof_types_supported': {'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'Ed25519'}}},\
+                    'proof_types_supported': {'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256'}}},\
                     'credential_definition': {\
                       'type': {'VerifiableCredential','MOSIPVerifiableCredential'},\
                       'credentialSubject': {\


### PR DESCRIPTION
IDA stack doesn't support proofJwt in Ed25519 and it shouldn't be included