### PR TITLE
[DSD-8382] Add credentials endpoint in certify-default properties

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -24,10 +24,10 @@ mosip.certify.security.auth.get-urls={}
 
 mosip.certify.security.ignore-csrf-urls=${server.servlet.path}/actuator/**,${server.servlet.path}/error,\
   ${server.servlet.path}/swagger-ui/**,${server.servlet.path}/v3/api-docs/**,\
-  ${server.servlet.path}/issuance/**,**/system-info/**
+  ${server.servlet.path}/issuance/**,**/system-info/**,**/credentials/**
 
 mosip.certify.security.ignore-auth-urls=/actuator/**,**/error,**/swagger-ui/**,\
-  **/v3/api-docs/**,**/issuance/**,**/system-info/**,**/rendering-template/**
+  **/v3/api-docs/**,**/issuance/**,**/system-info/**,**/rendering-template/**,**/credentials/**
 
 ## ------------------------------------------ Discovery openid-configuration -------------------------------------------
 


### PR DESCRIPTION
This PR is for accessing the credential config endpoint specifically for demo.