### PR TITLE
Updating "mosip.inji.user.wallet.pin.validation.regex" to 6

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -36,7 +36,7 @@ mosip.inji.qr.data.size.limit=10000
 mosip.inji.qr.code.height=650
 #Width of the QRCode
 mosip.inji.qr.code.width=650
-mosip.inji.user.wallet.pin.validation.regex=^\\d{4,6}$
+mosip.inji.user.wallet.pin.validation.regex=^\\d{6}$
 mosip.inji.user.wallet.name.validation.regex=^[A-Za-z0-9 _.-]{1,50}$
 
 #Inji Verify Config


### PR DESCRIPTION
1. Updating the "mosip.inji.user.wallet.pin.validation.regex" to 6
2. To make same as of dev-int-inji as part new Mimoto API test rig