### PR TITLE
Updated name for the CRE mosip issuer 

### DIFF
--- a/mimoto-issuers-config.json
+++ b/mimoto-issuers-config.json
@@ -164,7 +164,7 @@
       "credential_issuer_host": "https://${mosip.injicertify.mosipid.released.host}",
       "display": [
         {
-          "name": "National Identity Department (Released)",
+          "name": "National Identity Department",
           "logo": {
             "url": "https://mosip.github.io/inji-config/logos/mosipid-logo.png",
             "alt_text": "mosip-logo"


### PR DESCRIPTION
Updated name for the CRE mosip issuer to be compatible with mimoto so it can be compatible with api test rig validations