### PR TITLE
[INJICERT-1145] Add kid prepend property and overide mosipid proof types config

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -107,6 +107,10 @@ mosip.kernel.keymgr.hsm.health.key.app-id=CERTIFY_SERVICE
 mosip.kernel.keymgr.hsm.healthkey.ref-id=TRANSACTION_CACHE
 mosip.kernel.keymgr.hsm.health.check.encrypt=true
 
+# Set the keymanager prepend property to prepend specified value to the kid.
+# Supported Values: {'#', '<DOMAIN_NAME>#', 'PAYLOAD_ISSUER'}
+mosip.kernel.keymanager.signature.kid.prepend=PAYLOAD_ISSUER
+
 ##----------------------------------------- Database properties --------------------------------------------------------
 
 mosip.certify.database.hostname=postgres-postgresql.postgres

--- a/certify-mosipid-identity.properties
+++ b/certify-mosipid-identity.properties
@@ -65,6 +65,10 @@ mosip.certify.credential-config.issuer.display={\
     'locale': 'en'\
   }\
 }
+# Override proof types supported for the credential config 
+mosip.certify.credential-config.proof-types-supported={\
+  'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256'}}\
+}
 
 mosip.certify.key-values={\
  'vd11' : { \


### PR DESCRIPTION
1. Add keymanager kid prepend property.
2. Override supported proof types config for mosipid