### PR TITLE
Update certify-default.properties

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -180,5 +180,5 @@ mosip.certify.credential-config.credential-signing-alg-values-supported={\
   'eddsa-jcs-2022': {'EdDSA'}\
 }
 mosip.certify.credential-config.proof-types-supported={\
-  'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'Ed25519'}}\
+  'jwt': {'proof_signing_alg_values_supported': {'RS256'}}\
 }


### PR DESCRIPTION
Updated  'jwt': {'proof_signing_alg_values_supported': {'RS256'}}