### PR TITLE
Update certify-postgres-landregistry.properties

### DIFF
--- a/certify-postgres-landregistry.properties
+++ b/certify-postgres-landregistry.properties
@@ -12,7 +12,7 @@ mosip.certify.issuer.id.field.prefix.url=https://mosip.io/credential/
 ## --------------------------------------------DataProvider specific Certify configuration --------------------------------------------------- 
 # set custom VC expiry, supports limited subset of ISO-8601 Duration format starting from days to seconds
 # E.g. P21dT1h-2m3s for more information check javadoc of Duration.parse(String)
-mosip.certify.data-provider-plugin.vc-expiry-duration:P740d
+mosip.certify.data-provider-plugin.vc-expiry-duration:1000m
 # Cache-Control max-age value for rendering templates
 mosip.certify.rendering-template.cache-max-age-days=1
 


### PR DESCRIPTION
updated the mosip.certify.data-provider-plugin.vc-expiry-duration:1000m