### PR TITLE
Update certify-default.properties

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -184,7 +184,6 @@ mosip.certify.credential-config.credential-signing-alg-values-supported={\
   'EcdsaSecp256r1Signature2019': {'ES256'},\
   'ecdsa-rdfc-2019': {'ES256K'},\
   'ecdsa-jcs-2019': {'ES256K'},\
-  'eddsa-rdfc-2022': {'EdDSA'},\
   'eddsa-jcs-2022': {'EdDSA'}\
 }
 mosip.certify.credential-config.proof-types-supported={\
@@ -195,6 +194,8 @@ mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes={'r
 # Configuration for keyAliasMapper
 mosip.certify.signature-cryptosuite.key-alias-mapper={\
     'RsaSignature2018': {{'CERTIFY_VC_SIGN_RSA', ''}},\
+    'Ed25519Signature2018': {{'CERTIFY_VC_SIGN_ED25519', 'ED25519_SIGN'}},\
+    'Ed25519Signature2020': {{'CERTIFY_VC_SIGN_ED25519', 'ED25519_SIGN'}},\
     'EcdsaKoblitzSignature2016': {{'CERTIFY_VC_SIGN_EC_K1', 'EC_SECP256K1_SIGN'}},\
     'EcdsaSecp256k1Signature2019': {{'CERTIFY_VC_SIGN_EC_K1', 'EC_SECP256K1_SIGN'}},\
     'EcdsaSecp256r1Signature2019': {{'CERTIFY_VC_SIGN_EC_R1', 'EC_SECP256R1_SIGN'}}\


### PR DESCRIPTION
Reverted key mapper config and removed 'eddsa-rdfc-2022': {'EdDSA'},\ value from cryptosuite config property