### PR TITLE
Update certify-default.properties

### DIFF
--- a/certify-default.properties
+++ b/certify-default.properties
@@ -188,7 +188,7 @@ mosip.certify.credential-config.credential-signing-alg-values-supported={\
   'eddsa-jcs-2022': {'EdDSA'}\
 }
 mosip.certify.credential-config.proof-types-supported={\
-  'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'Ed25519'}}\
+  'jwt': {'proof_signing_alg_values_supported': {'RS256', 'PS256', 'ES256', 'ES256K', 'Ed25519'}}\
 }
 #Case-sensitive list of status purposes that are allowed to be configured for credential types in credential configuration.
 mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes={'revocation'}


### PR DESCRIPTION
added es256k to  'jwt': {'proof_signing_alg_values_supported':