### PR TITLE
trusted verifier cache time set to 1 minute

### DIFF
--- a/mimoto-default.properties
+++ b/mimoto-default.properties
@@ -69,6 +69,8 @@ cache.issuers-config.expiry-time-in-min = 60
 # Cache expiry time in minutes for the authentication server's well-known endpoint response.
 cache.credential-issuer.authserver-wellknown.expiry-time-in-min = 60
 # Default cache expiry time in minutes for others cache types
+# Cache expiry time in minutes for the pre-registered trusted verifiers list.
+cache.pre-registered-trusted-verifiers.expiry-time-in-min= 1
 cache.default.expiry-time-in-min = 60
 
 logging.level.org.springframework.web.client.RestTemplate=INFO


### PR DESCRIPTION
# Cache expiry time in minutes for the pre-registered trusted verifiers list. cache.pre-registered-trusted-verifiers.expiry-time-in-min=1